### PR TITLE
remove wrong comapre

### DIFF
--- a/bumpy/main.go
+++ b/bumpy/main.go
@@ -60,7 +60,7 @@ func main() {
 		}()
 
 		e := args[0]
-		if e.Get("target") != canvasEl {
+		if e.Get("target").Type() != canvasEl.Type() {
 			return nil
 		}
 		mx := e.Get("clientX").Float() * worldScale


### PR DESCRIPTION
 invalid operation: e.Get("target") != canvasEl (struct containing [0]func() cannot be compared)